### PR TITLE
Strip trailing spaces in server messages

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -102,6 +102,7 @@ func unescapeTagValue(value string) string {
 func parseToEvent(msg string) (*Event, error) {
 	msg = strings.TrimSuffix(msg, "\n") //Remove \r\n
 	msg = strings.TrimSuffix(msg, "\r")
+	msg = strings.TrimRight(msg, " ") // workaround; some servers add trailing spaces
 	event := &Event{Raw: msg}
 	if len(msg) < 5 {
 		return nil, errors.New("Malformed msg from server")


### PR DESCRIPTION
Add workaround to fix freenode SASL auth.
At least one freende server (weber.freenode.net) adds a space to the reply:

    2019/02/28 17:42:40 <-- ":weber.freenode.net CAP * ACK :account-notify \r\n"
    2019/02/28 17:42:40 <-- ":weber.freenode.net CAP * ACK :sasl \r\n"

It looks like a server bug, but other IRC clients ignore trailing spaces, and I think it is a good idea to ignore them in go-ircevent too.